### PR TITLE
On case-sensitive filesystems include statments must exactly match the f...

### DIFF
--- a/Mcp3008.cpp
+++ b/Mcp3008.cpp
@@ -1,4 +1,12 @@
-#include "MCP3008.h"
+/*
+MCP3008 Library Copyright 2014 by Jason Campbell
+
+Revisions:
+    infomaniac50 - Sun Mar  8 12:12:04 CDT 2015
+    On case-sensitive filesystems include statments must exactly match the filename.
+ */
+
+#include "Mcp3008.h"
 
 Mcp3008::Mcp3008(byte adcChipSelectPin) {
 


### PR DESCRIPTION
I use linux and the ext4 filesystem is case sensitive. The example failed to compile since the include statement in Mcp3008.cpp used all caps `#include MCP3008.cpp` which of course doesn't exist for somebody on linux and maybe on OS X too.
